### PR TITLE
Replace job query with status query

### DIFF
--- a/client.go
+++ b/client.go
@@ -125,12 +125,13 @@ func (t *PipelineGateEdgeFragment) GetNode() *PipelineGateFragment {
 }
 
 type PipelineGateFragment struct {
-	ID        string            "json:\"id\" graphql:\"id\""
-	Name      string            "json:\"name\" graphql:\"name\""
-	Type      GateType          "json:\"type\" graphql:\"type\""
-	State     GateState         "json:\"state\" graphql:\"state\""
-	UpdatedAt *string           "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	Spec      *GateSpecFragment "json:\"spec,omitempty\" graphql:\"spec\""
+	ID        string              "json:\"id\" graphql:\"id\""
+	Name      string              "json:\"name\" graphql:\"name\""
+	Type      GateType            "json:\"type\" graphql:\"type\""
+	State     GateState           "json:\"state\" graphql:\"state\""
+	UpdatedAt *string             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	Spec      *GateSpecFragment   "json:\"spec,omitempty\" graphql:\"spec\""
+	Status    *GateStatusFragment "json:\"status,omitempty\" graphql:\"status\""
 }
 
 func (t *PipelineGateFragment) GetID() string {
@@ -169,6 +170,12 @@ func (t *PipelineGateFragment) GetSpec() *GateSpecFragment {
 	}
 	return t.Spec
 }
+func (t *PipelineGateFragment) GetStatus() *GateStatusFragment {
+	if t == nil {
+		t = &PipelineGateFragment{}
+	}
+	return t.Status
+}
 
 type GateSpecFragment struct {
 	Job *JobSpecFragment "json:\"job,omitempty\" graphql:\"job\""
@@ -179,6 +186,17 @@ func (t *GateSpecFragment) GetJob() *JobSpecFragment {
 		t = &GateSpecFragment{}
 	}
 	return t.Job
+}
+
+type GateStatusFragment struct {
+	JobRef *JobReferenceFragment "json:\"jobRef,omitempty\" graphql:\"jobRef\""
+}
+
+func (t *GateStatusFragment) GetJobRef() *JobReferenceFragment {
+	if t == nil {
+		t = &GateStatusFragment{}
+	}
+	return t.JobRef
 }
 
 type JobSpecFragment struct {
@@ -225,6 +243,24 @@ func (t *JobSpecFragment) GetServiceAccount() *string {
 		t = &JobSpecFragment{}
 	}
 	return t.ServiceAccount
+}
+
+type JobReferenceFragment struct {
+	Name      string "json:\"name\" graphql:\"name\""
+	Namespace string "json:\"namespace\" graphql:\"namespace\""
+}
+
+func (t *JobReferenceFragment) GetName() string {
+	if t == nil {
+		t = &JobReferenceFragment{}
+	}
+	return t.Name
+}
+func (t *JobReferenceFragment) GetNamespace() string {
+	if t == nil {
+		t = &JobReferenceFragment{}
+	}
+	return t.Namespace
 }
 
 type ContainerSpecFragment struct {
@@ -13501,6 +13537,9 @@ fragment PipelineGateFragment on PipelineGate {
 	spec {
 		... GateSpecFragment
 	}
+	status {
+		... GateStatusFragment
+	}
 }
 fragment GateSpecFragment on GateSpec {
 	job {
@@ -13528,6 +13567,15 @@ fragment ContainerSpecFragment on ContainerSpec {
 		configMap
 		secret
 	}
+}
+fragment GateStatusFragment on GateStatus {
+	jobRef {
+		... JobReferenceFragment
+	}
+}
+fragment JobReferenceFragment on JobReference {
+	name
+	namespace
 }
 `
 
@@ -13574,6 +13622,9 @@ fragment PipelineGateFragment on PipelineGate {
 	spec {
 		... GateSpecFragment
 	}
+	status {
+		... GateStatusFragment
+	}
 }
 fragment GateSpecFragment on GateSpec {
 	job {
@@ -13601,6 +13652,15 @@ fragment ContainerSpecFragment on ContainerSpec {
 		configMap
 		secret
 	}
+}
+fragment GateStatusFragment on GateStatus {
+	jobRef {
+		... JobReferenceFragment
+	}
+}
+fragment JobReferenceFragment on JobReference {
+	name
+	namespace
 }
 `
 
@@ -13638,6 +13698,9 @@ fragment PipelineGateFragment on PipelineGate {
 	spec {
 		... GateSpecFragment
 	}
+	status {
+		... GateStatusFragment
+	}
 }
 fragment GateSpecFragment on GateSpec {
 	job {
@@ -13665,6 +13728,15 @@ fragment ContainerSpecFragment on ContainerSpec {
 		configMap
 		secret
 	}
+}
+fragment GateStatusFragment on GateStatus {
+	jobRef {
+		... JobReferenceFragment
+	}
+}
+fragment JobReferenceFragment on JobReference {
+	name
+	namespace
 }
 `
 
@@ -13700,6 +13772,9 @@ fragment PipelineGateFragment on PipelineGate {
 	spec {
 		... GateSpecFragment
 	}
+	status {
+		... GateStatusFragment
+	}
 }
 fragment GateSpecFragment on GateSpec {
 	job {
@@ -13727,6 +13802,15 @@ fragment ContainerSpecFragment on ContainerSpec {
 		configMap
 		secret
 	}
+}
+fragment GateStatusFragment on GateStatus {
+	jobRef {
+		... JobReferenceFragment
+	}
+}
+fragment JobReferenceFragment on JobReference {
+	name
+	namespace
 }
 `
 

--- a/graph/gates.graphql
+++ b/graph/gates.graphql
@@ -24,10 +24,15 @@ fragment PipelineGateFragment on PipelineGate {
     state
     updatedAt
     spec { ...GateSpecFragment }
+    status { ...GateStatusFragment }
 }
 
 fragment GateSpecFragment on GateSpec {
     job { ...JobSpecFragment }
+}
+
+fragment GateStatusFragment on GateStatus {
+  jobRef { ...JobReferenceFragment }
 }
 
 fragment JobSpecFragment on JobGateSpec {
@@ -37,6 +42,11 @@ fragment JobSpecFragment on JobGateSpec {
     labels
     annotations
     serviceAccount
+}
+
+fragment JobReferenceFragment on JobReference {
+  name
+  namespace
 }
 
 fragment ContainerSpecFragment on ContainerSpec {

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -306,6 +306,14 @@ type RootQueryType {
 
   clusterRestore(id: ID!): ClusterRestore
 
+  notificationSink(name: String, id: ID): NotificationSink
+
+  notificationRouter(name: String, id: ID): NotificationRouter
+
+  notificationSinks(after: String, first: Int, before: String, last: Int): NotificationSinkConnection
+
+  notificationRouters(after: String, first: Int, before: String, last: Int): NotificationSinkConnection
+
   deploymentSettings: DeploymentSettings
 }
 
@@ -610,6 +618,14 @@ type RootMutationType {
 
   updateClusterRestore(id: ID!, attributes: RestoreAttributes!): ClusterRestore
 
+  upsertNotificationSink(attributes: NotificationSinkAttributes!): NotificationSink
+
+  upsertNotificationRouter(attributes: NotificationRouterAttributes!): NotificationRouter
+
+  deleteNotificationSink(id: ID!): NotificationSink
+
+  deleteNotificationRouter(id: ID!): NotificationRouter
+
   "a reusable mutation for updating rbac settings on core services"
   updateRbac(rbac: RbacAttributes!, serviceId: ID, clusterId: ID, providerId: ID): Boolean
 
@@ -729,6 +745,121 @@ input HttpConnectionAttributes {
 input RbacAttributes {
   readBindings: [PolicyBindingAttributes]
   writeBindings: [PolicyBindingAttributes]
+}
+
+enum SinkType {
+  SLACK
+  TEAMS
+}
+
+input NotificationSinkAttributes {
+  "the name of this sink"
+  name: String!
+
+  "the channel type of this sink"
+  type: SinkType!
+
+  "configuration for the specific type"
+  configuration: SinkConfigurationAttributes!
+}
+
+input SinkConfigurationAttributes {
+  slack: UrlSinkAttributes
+  teams: UrlSinkAttributes
+}
+
+input UrlSinkAttributes {
+  url: String!
+}
+
+input NotificationRouterAttributes {
+  "the name of this router"
+  name: String!
+
+  "the events to trigger, or use * for any"
+  events: [String!]
+
+  "filters by object type"
+  filters: [RouterFilterAttributes]
+
+  "sinks to deliver notifications to"
+  routerSinks: [RouterSinkAttributes]
+}
+
+input RouterFilterAttributes {
+  "whether to enable delivery for events associated with this service"
+  serviceId: ID
+
+  "whether to enable delivery for events associated with this cluster"
+  clusterId: ID
+
+  "whether to enable delivery for events associated with this pipeline"
+  pipelineId: ID
+}
+
+input RouterSinkAttributes {
+  sinkId: ID!
+}
+
+type NotificationSink {
+  id: ID!
+
+  "the name of the sink"
+  name: String!
+
+  "the channel type of the sink, eg slack or teams"
+  type: SinkType!
+
+  "type specific sink configuration"
+  configuration: SinkConfiguration!
+
+  insertedAt: DateTime
+
+  updatedAt: DateTime
+}
+
+type NotificationRouter {
+  id: ID!
+
+  "name of this router"
+  name: String!
+
+  "events this router subscribes to, use * for all"
+  events: [String!]
+
+  "resource-based filters to select events for services, clusters, pipelines"
+  filters: [NotificationFilter]
+
+  "sinks to deliver notifications to"
+  sinks: [NotificationSink]
+
+  insertedAt: DateTime
+
+  updatedAt: DateTime
+}
+
+type NotificationFilter {
+  id: ID!
+  service: Service
+  cluster: Cluster
+  pipeline: Pipeline
+}
+
+type SinkConfiguration {
+  id: ID!
+  slack: UrlSinkConfiguration
+  teams: UrlSinkConfiguration
+}
+
+"A notification sink based off slack incoming webhook urls"
+type UrlSinkConfiguration {
+  "incoming webhook url to deliver to"
+  url: String!
+}
+
+type NotificationSinkConnection {
+  pageInfo: PageInfo!
+  edges: [NotificationSinkEdge]
 }
 
 enum RestoreStatus {
@@ -1105,6 +1236,9 @@ type PipelineGate {
   "more detailed specification for complex gates"
   spec: GateSpec
 
+  "state related to the current status of this job"
+  status: GateStatus
+
   "the kubernetes job running this gate (should only be fetched lazily as this is a heavy operation)"
   job: Job
 
@@ -1122,6 +1256,11 @@ type PipelineGate {
 "detailed gate specifications"
 type GateSpec {
   job: JobGateSpec
+}
+
+"state delineating the current status of this gate"
+type GateStatus {
+  jobRef: JobReference
 }
 
 "the full specification of a job gate"
@@ -4764,5 +4903,10 @@ type ClusterBackupEdge {
 
 type ObjectStoreEdge {
   node: ObjectStore
+  cursor: String
+}
+
+type NotificationSinkEdge {
+  node: NotificationSink
   cursor: String
 }


### PR DESCRIPTION
We need to not sideload jobs when querying gates, the status embed should alleviate this.